### PR TITLE
Release 0.0.1: PR body format for issue linking and In Review workflow

### DIFF
--- a/.cursor/commands/github-pm.md
+++ b/.cursor/commands/github-pm.md
@@ -89,6 +89,27 @@ Use this when the user asks to create an issue, describes work to track, or repo
 
 - User says "github-pm", "project manager", "manage project", "check project", "sprint issues", "weekly report", "clean up issues", "break down this into issues", "add these to backlog", "discussions to issues", etc.
 - User asks to create an issue and you want a single entry point: you can still route to create and follow the create flow above.
+- User asks to create or edit a PR to **development** that should move issues to In Review on merge: follow the format in **"PRs to development: linking issues so they move to In Review"** so each linked issue uses a closing keyword (e.g. `Closes #N` per issue).
+
+## PRs to development: linking issues so they move to In Review
+
+When creating or editing a PR that targets the **development** branch, link issues in the PR body so that the workflow `.github/workflows/update-project-on-merge-to-dev.yml` can move those issues to **In Review** when the PR is merged.
+
+**Required format (workflow-compatible):**
+
+- The workflow only recognizes these patterns in the PR **body**:
+  - `Closes #123`, `Fixes #123`, `Resolves #123` (and lowercase variants like `closes`, `fixes`, `resolves`).
+  - `Related to: #123` (template-style).
+- **Each issue number must be preceded by a closing/linking keyword.** A single phrase like `Closes #11, #13, #20` is parsed as only **one** linked issue (#11). To link multiple issues, use one of:
+  - One keyword per issue on one line: `Closes #11, closes #13, closes #20`
+  - One per line:
+    - `Closes #11`
+    - `Closes #13`
+    - `Closes #20`
+  - Or: `Closes #11. Closes #13. Closes #20`
+- Linked issues must exist as **items in the GitHub Project** named **"Chat Template Project"**. If an issue is not in that project, the workflow will not update its status to In Review (and will log "Issue #N not found in project").
+
+When you are asked to create or describe a PR to development (e.g. from a feature branch or `ci_cd`), use the format above for every issue that should move to In Review on merge.
 
 ## When Not to Use
 


### PR DESCRIPTION
## Summary
Follow-up PR from `ci_cd` to `development`: updates docs (github-pm command) for linking issues in PRs and uses the **workflow-compatible Closes format** so that when this PR is merged, linked issues are moved to **In Review** by `.github/workflows/update-project-on-merge-to-dev.yml` and closed by GitHub.

## Release Information
- [ ] This PR is for a release (development → main)
- **Release Tag:** `v0.0.1`
- **Milestone:** v0.0.1

## Type of Change
- [ ] Feature
- [ ] Bug Fix
- [x] Task
- [x] Documentation Update
- [ ] Other (please describe):

## Related Issues
Use one closing keyword per issue so the In Review workflow and GitHub both recognize every linked issue:

Closes #11. Closes #13. Closes #20. Closes #21. Closes #33. Closes #37. Closes #38. Closes #41. Closes #45.

## Changes Made
- Documentation: `.cursor/commands/github-pm.md` — added section on PR-to-development issue linking format and "When to Use" note for PRs targeting development.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Tests pass locally

## Documentation
- [x] Other documentation updated (github-pm command)

## Checklist
- [x] Code follows project code standards
- [x] Documentation is up to date
- [x] Branch is up to date with target branch

## Additional Notes
When merging, if you use **Squash and merge**, include the `Closes #11. Closes #13. ...` line in the **merge commit message** so GitHub closes these issues. The PR body format above ensures the update-project-on-merge-to-dev workflow will set each issue to In Review when this PR is merged to `development`.

Made with [Cursor](https://cursor.com)