### PR TITLE
Release v0.0.2: CI/CD fixes and release workflow improvement

### DIFF
--- a/.github/workflows/create-release-on-merge.yml
+++ b/.github/workflows/create-release-on-merge.yml
@@ -25,60 +25,35 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Get the commit that was just pushed
-            const commits = await github.rest.repos.listCommits({
+            // Use GitHub API to get PR(s) associated with this commit (works for merge, squash, rebase)
+            const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              sha: '${{ github.sha }}',
-              per_page: 10
+              commit_sha: context.sha
             });
             
-            // Find the merge commit (usually contains "Merge pull request")
-            let mergedPR = null;
-            for (const commit of commits.data) {
-              const message = commit.commit.message;
-              const prMatch = message.match(/Merge pull request #(\d+)/);
-              
-              if (prMatch) {
-                const prNumber = parseInt(prMatch[1]);
-                try {
-                  const pr = await github.rest.pulls.get({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: prNumber
-                  });
-                  
-                  // Check if this PR is from development to main
-                  if (pr.data.base.ref === 'main' && pr.data.head.ref === 'development') {
-                    mergedPR = {
-                      number: prNumber,
-                      body: pr.data.body || '',
-                      title: pr.data.title,
-                      milestone: pr.data.milestone ? {
-                        title: pr.data.milestone.title,
-                        number: pr.data.milestone.number
-                      } : null
-                    };
-                    break;
-                  }
-                } catch (error) {
-                  console.log(`Could not fetch PR #${prNumber}: ${error.message}`);
-                }
-              }
-            }
+            // Find the PR that targeted main with head development (the one we just merged into main)
+            const mergedPR = pulls.find(pr => pr.base && pr.base.ref === 'main' && pr.head && pr.head.ref === 'development');
             
             if (!mergedPR) {
-              console.log('No PR from development → main found in recent commits');
+              console.log('No PR from development → main found for this commit');
               return { found: false };
             }
             
+            // Get full PR for body, title, milestone
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: mergedPR.number
+            });
+            
             return {
               found: true,
-              pr_number: mergedPR.number,
-              pr_body: mergedPR.body,
-              pr_title: mergedPR.title,
-              milestone_title: mergedPR.milestone?.title || '',
-              milestone_number: mergedPR.milestone?.number || ''
+              pr_number: pr.number,
+              pr_body: pr.body || '',
+              pr_title: pr.title,
+              milestone_title: pr.milestone ? pr.milestone.title : '',
+              milestone_number: pr.milestone ? String(pr.milestone.number) : ''
             };
 
       - name: Extract release tag from PR body

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -204,10 +204,10 @@ jobs:
           MASTER_DB_USERNAME: ${{ secrets.MASTER_DB_USERNAME }}
           LAMBDA_IMAGE_URI: ${{ inputs.lambda_image_uri }}
           PROMOTE_LAMBDA_FROM_ENV: ${{ inputs.promote_lambda_from_env }}
-          PROMOTION_SOURCE_ROLE_ARN: ${{ inputs.promotion_source_role_arn }}
+          PROMOTION_SOURCE_ROLE_ARN: ${{ inputs.promotion_source_role_arn || secrets.STAGING_DEPLOYER_ROLE_ARN || '' }}
           PROMOTION_SOURCE_IMAGE_URI: ${{ inputs.promotion_source_image_uri }}
           PROMOTE_KB_FROM_ENV: ${{ inputs.promote_kb_from_env }}
-          PROMOTION_KB_SOURCE_ROLE_ARN: ${{ inputs.promotion_kb_source_role_arn }}
+          PROMOTION_KB_SOURCE_ROLE_ARN: ${{ inputs.promotion_kb_source_role_arn || secrets.STAGING_DEPLOYER_ROLE_ARN || '' }}
         run: |
           # Base command: deploy with auto-confirm
           CMD="./scripts/deploy/deploy_all.sh ${ENVIRONMENT} -y"

--- a/.github/workflows/deploy_prod_on_merge.yml
+++ b/.github/workflows/deploy_prod_on_merge.yml
@@ -39,9 +39,8 @@ jobs:
       skip_ecr: true
       skip_lambda: false
       promote_kb_from_env: staging
-      promotion_kb_source_role_arn: ${{ secrets.STAGING_DEPLOYER_ROLE_ARN }}
       promote_lambda_from_env: staging
-      promotion_source_role_arn: ${{ secrets.STAGING_DEPLOYER_ROLE_ARN }}
+      # Role ARNs are read from prod env secret STAGING_DEPLOYER_ROLE_ARN in deploy.yml when inputs are empty
     secrets: inherit
 
   # Run evals after deploy so they run within the newly deployed prod environment.


### PR DESCRIPTION
## Summary
This PR promotes `development` to `main` for release **v0.0.2**, including the CI/CD improvements merged via PR #72: release workflow fix (issue #71), deploy and evals workflow updates, and project automation.

## Release Information
- [x] This PR is for a release (development → main)
- **Release Tag:** `v0.0.2`
- **Milestone:** v0.0.2

## Type of Change
- [x] Feature
- [x] Bug Fix
- [x] Task
- [x] Documentation Update

## Related Issues
- Closes #71

## Changes Made
- **Release workflow (fixes #71):** Create Release on Merge to Main now uses GitHub API `listPullRequestsAssociatedWithCommit` to detect the merged development→main PR, so release creation works for squash merge and rebase merge as well as merge commits.
- **Deploy workflows:** Read role ARNs from secrets when inputs are empty; `deploy_prod_on_merge` supports evaluation uploads and staging→prod promotion; optional Lambda/KB promotion parameters.
- **run-evals workflow:** Boolean `upload_to_main` option; clarified permissions and comments.
- **Project automation:** Update project status on merge to development (issue linking, PROJECT_TOKEN check); `submit-pr` command and PR template updates; docs and setup script updates.

## Testing
- [x] Manual testing performed
- [x] Tests pass (CI on PR #72)

## Documentation
- [x] README/docs updated where applicable
- [x] CHANGELOG.md will be updated by release workflow on merge

## Checklist
- [x] Code follows project standards
- [x] All tests pass
- [x] Branch is up to date with target branch
- [x] No merge conflicts

## Additional Notes
Merge this PR (squash or merge commit) to `main` to trigger the Create Release on Merge to Main workflow, which will create GitHub release v0.0.2 and update CHANGELOG.

Made with [Cursor](https://cursor.com)